### PR TITLE
Reboot and Kill Commands

### DIFF
--- a/commands/utilities/kill.js
+++ b/commands/utilities/kill.js
@@ -1,0 +1,25 @@
+const { Command } = require('discord.js-commando');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class kill extends Command {
+  constructor(client) {
+    super(client, {
+      name: 'kill',
+      aliases: ['stop-bot'],
+      memberName: 'kill',
+      group: 'utilities',
+      description: 'Stops MercChan',
+      guildOnly: true,
+      clientPermissions: ['SPEAK', 'CONNECT'],
+      hidden: true,
+    });
+  }
+  hasPermission(message) {
+    if (message.member.roles.highest.name.includes('⚔️ Commander')) return true;
+    return 'Commanders Only';
+  }
+
+  run(message) {
+    process.exit(0);
+  }
+};

--- a/commands/utilities/reboot.js
+++ b/commands/utilities/reboot.js
@@ -1,5 +1,8 @@
 const { Command } = require('discord.js-commando');
 const { MessageEmbed } = require('discord.js');
+const axios = require('axios');
+require('dotenv').config();
+const postSite = process.env.postSite;
 
 module.exports = class reboot extends Command {
   constructor(client) {
@@ -11,6 +14,7 @@ module.exports = class reboot extends Command {
       description: 'Reboot MercChan',
       guildOnly: true,
       clientPermissions: ['SPEAK', 'CONNECT'],
+      hidden: true,
     });
   }
   hasPermission(message) {
@@ -18,7 +22,17 @@ module.exports = class reboot extends Command {
     return 'Command for Premium Members Only';
   }
 
-  run(message) {
-    process.exit(0);
+  async run(message) {
+    //process.exit(0);
+    axios({
+      method: 'post',
+      url: `${postSite}/command`,
+      headers: { 'contenct-type': 'application/x-www-form-urlencoded' },
+      data: {
+        cli: 'pm2',
+        action: 'restart',
+        processName: 'mercchan --watch',
+      },
+    });
   }
 };


### PR DESCRIPTION
Moved reboot to kill command and added new reboot command to use a POST request. These commands are now hidden from !help.