### PR TITLE
Added characterlist, renamed charactercreate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,31 @@ Mercs Discord Bot
 
 ## Usage
 
-| Command       | Args                           | Permissions                    | Description                                   |
-| ------------- | ------------------------------ | ------------------------------ | --------------------------------------------- |
-| !deal         | Game                           | Anyone                         | Search IsThereAnyDeal for game deals.a        |
-| !weather      | zipcode                        | Anyone                         | Returns local weather for your zipcode        |
-| !humble       | Game, # of players, Time, Date | COMMANDER / Division Commander | Creates a new event in the channel            |
-| !rocketleague | Steam ID                       | Anyone                         | Checks Rocket League stats for a Steam name   |
-| **Music**     |                                |                                |                                               |
-| !play         | Youtube Playlist or Song       | COMMANDER / PREMIUM MEMBER     | Plays a Youtube playlist                      |
-| !skip         |                                | COMMANDER / PREMIUM MEMBER     | Skips 1 track in playlist                     |
-| !skipto       | Playlist Index                 | COMMANDER / PREMIUM MEMBER     | Skips forward to designated track in playlist |
-| !queue        |                                | COMMANDER / PREMIUM MEMBER     | Displays the playlist queue                   |
-| !leave        |                                | COMMANDER / PREMIUM MEMBER     | Removes MercChan from the voice channel       |
-| **Events**    |                                |                                |                                               |
-| !event        | Game, # of players, Time, Date | COMMANDER / Division Commander | Creates a new event in the channel            |
-| !cleanevents  | Number of days past the event  | COMMANDER / Division Commander | Deletes Role and Channel associate with event |
-| **RPG**       |                                |                                |                                               |
-| !roll         | [# of dice]d[size of dice]     | Anyone                         | Replies with dice rolls                       |
-| !coinflip     |                                | Anyone                         | Replies with a head or tails coin image       |
-| **Admin**     |                                |                                |                                               |
-| !reboot       |                                | COMMANDER                      | Sends webhook to reboot MercChan              |
-| !kill         |                                | COMMANDER                      | Kills MercChan Process                        |
-| !purge        | # (1-100)                      | COMMANDER                      | Deletes the last x messages from channel      |
-| !say          | title, announcement            | COMMANDER                      | Sands a message to the announcements channel  |
+| Command          | Args                           | Permissions                    | Description                                   |
+| ---------------- | ------------------------------ | ------------------------------ | --------------------------------------------- |
+| !deal            | Game                           | Anyone                         | Search IsThereAnyDeal for game deals.a        |
+| !weather         | zipcode                        | Anyone                         | Returns local weather for your zipcode        |
+| !humble          | Game, # of players, Time, Date | COMMANDER / Division Commander | Creates a new event in the channel            |
+| !rocketleague    | Steam ID                       | Anyone                         | Checks Rocket League stats for a Steam name   |
+| **Music**        |                                |                                |                                               |
+| !play            | Youtube Playlist or Song       | COMMANDER / PREMIUM MEMBER     | Plays a Youtube playlist                      |
+| !skip            |                                | COMMANDER / PREMIUM MEMBER     | Skips 1 track in playlist                     |
+| !skipto          | Playlist Index                 | COMMANDER / PREMIUM MEMBER     | Skips forward to designated track in playlist |
+| !queue           |                                | COMMANDER / PREMIUM MEMBER     | Displays the playlist queue                   |
+| !leave           |                                | COMMANDER / PREMIUM MEMBER     | Removes MercChan from the voice channel       |
+| **Events**       |                                |                                |                                               |
+| !event           | Game, # of players, Time, Date | COMMANDER / Division Commander | Creates a new event in the channel            |
+| !cleanevents     | Number of days past the event  | COMMANDER / Division Commander | Deletes Role and Channel associate with event |
+| **RPG**          |                                |                                |                                               |
+| !roll            | [# of dice]d[size of dice]     | Anyone                         | Replies with dice rolls                       |
+| !coinflip        |                                | Anyone                         | Replies with a head or tails coin image       |
+| !charactercreate | Charcter first and last name   | Anyone                         | Creates an RPG character in the database      |
+| !characterlist   | mention user (optional)        | Anyone                         | Replies with a list of RPG characters created |
+| **Admin**        |                                |                                |                                               |
+| !reboot          |                                | COMMANDER                      | Sends webhook to reboot MercChan              |
+| !kill            |                                | COMMANDER                      | Kills MercChan Process                        |
+| !purge           | # (1-100)                      | COMMANDER                      | Deletes the last x messages from channel      |
+| !say             | title, announcement            | COMMANDER                      | Sands a message to the announcements channel  |
 
 ## Requirements
 

--- a/commands/rpg/charactercreate.js
+++ b/commands/rpg/charactercreate.js
@@ -2,12 +2,12 @@ const { Command } = require('discord.js-commando');
 const db = require('../../Firebase/firebase.js');
 const { doc } = require('../../Firebase/firebase.js');
 
-module.exports = class createCharacter extends Command {
+module.exports = class characterCreate extends Command {
   constructor(client) {
     super(client, {
-      name: 'createcharacter',
-      aliases: ['create-char'],
-      memberName: 'createcharacter',
+      name: 'charactercreate',
+      aliases: ['ccreate'],
+      memberName: 'charactercreate',
       group: 'rpg',
       description: 'Create a new character',
       throttling: {
@@ -16,13 +16,6 @@ module.exports = class createCharacter extends Command {
       },
       clientPermissions: ['SEND_MESSAGES'],
     });
-  }
-
-  hasPermission(message) {
-    const approvedRoles = ['⚔️ Commander'];
-    const title = message.member.roles.highest.name;
-    if (approvedRoles.includes(title)) return true;
-    return 'Command under development';
   }
 
   async run(message) {

--- a/commands/rpg/characterlist.js
+++ b/commands/rpg/characterlist.js
@@ -1,0 +1,77 @@
+const { Command } = require('discord.js-commando');
+const { MessageEmbed } = require('discord.js');
+const db = require('../../Firebase/firebase.js');
+const { doc } = require('../../Firebase/firebase.js');
+
+module.exports = class characterList extends Command {
+  constructor(client) {
+    super(client, {
+      name: 'characterlist',
+      aliases: ['clist'],
+      memberName: 'characterlist',
+      group: 'rpg',
+      description: 'List Characters',
+      throttling: {
+        usages: 1,
+        duration: 1,
+      },
+      clientPermissions: ['SEND_MESSAGES'],
+    });
+  }
+
+  async run(message) {
+    const args = message.content.split(' ');
+    let discordID;
+    let discordUser;
+    let mentionedUser;
+
+    if (args[1] && message.guild) {
+      // Lookup mentionied users ID
+      mentionedUser = message.mentions.users.first();
+      if (mentionedUser) {
+        discordID = mentionedUser.id;
+        discordUser = mentionedUser.username;
+      } else {
+        return message.say('Discord Member Not Found');
+      }
+    } else {
+      // Use command author
+      discordID = message.author.id;
+      discordUser = message.author.username;
+    }
+
+    //Query user Characters
+    const rpgCollection = db.collection('rpg');
+    const userChars = await rpgCollection
+      .where('discordID', '==', discordID)
+      .orderBy('order')
+      .get();
+
+    const messageContent = [];
+    const charQty = userChars.size;
+    let embed = new MessageEmbed();
+    embed.setTitle(`${discordUser} has ${charQty} Characters`);
+    if (charQty === 0) {
+      return message.say(`${discordUser} has no characters`);
+    } else {
+      userChars.forEach((doc) => {
+        embed.addField(`Character ${doc.data().order}:`, doc.data().name);
+        messageContent.push(
+          `${discordUser} ${doc.data().order}: ${doc.data().name}`
+        );
+      });
+    }
+
+    if (message.guild) {
+      message.embed(embed);
+    } else {
+      if (args[1])
+        message.say(
+          'Cannot lookup other users in DM, here are your characters: '
+        );
+      messageContent.forEach((content) => {
+        message.say(content);
+      });
+    }
+  }
+};


### PR DESCRIPTION
Renamed create character to character create so all RPG character commands start the same. They will all support an alias following c[action], ie ccreate, clist. Added the character list command. Supports personal lookup through dm or lookup via mention in a channel.